### PR TITLE
Allow using TCP socket instead of unix socket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ php_fpm_settings:
   - { option: group,  value: "app" }
 ```
 
-#### FPM Socket
-A path to PHP-fpm socket.  
+#### FPM Listen
+A path to PHP-fpm socket or an address to bind server to.  
 Defaults to `/var/run/php5-fpm.sock`.
 
 ```yml
-php_fpm_socket: /var/run/application.sock
+php_fpm_listen: /var/run/php5-fpm.sock
 ```
 
 ### PHP Extensions

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ composer_path: '/usr/local/bin'
 
 # PHP
 php_ini_settings: []
-php_fpm_socket: /var/run/php5-fpm.sock
+php_fpm_listen: 127.0.0.1:9000
 php_fpm_settings: []
 
 # PHP Extensions

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,9 +3,8 @@
 
 # PHP
 php_fpm_defaults:
-  - { option: listen,                 value: "{{ php_fpm_socket }}" }
+  - { option: listen,                 value: "{{ php_fpm_listen }}" }
   - { option: listen.allowed_clients, value: "127.0.0.1" }
-  - { option: listen.mode,            value: "0600" }
 
 # PHP Extensions
 php_extensions_defaults:


### PR DESCRIPTION
Rename `php_fpm_socket` to `php_fpm_listen` and allow using network address instead of unix socket.
