### PR TITLE
Forces newrelic-sysmond installation to avoid interactive dialogs.

### DIFF
--- a/tasks/php-thirdparty.yml
+++ b/tasks/php-thirdparty.yml
@@ -19,7 +19,7 @@
 
 - name: PHP Third Party | New Relic | Install New Relic server agent
   sudo: yes
-  apt: name=newrelic-sysmond state=latest
+  apt: name=newrelic-sysmond state=latest force=yes
   when: php_thirdparty_newrelic
 
 - name: PHP Third Party | New Relic | Setup New Relic Server Monitor License


### PR DESCRIPTION
Fixes

```
TASK: [dosomething.web | PHP Third Party | New Relic | Install New Relic server agent] ***
failed: [default] => {"failed": true}
stderr: E: There are problems and -y was used without --force-yes
```
